### PR TITLE
[push_to_hub] Add data_files in yaml

### DIFF
--- a/src/datasets/arrow_dataset.py
+++ b/src/datasets/arrow_dataset.py
@@ -5415,6 +5415,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin, TensorflowDatasetMixin):
                 data_files_to_dump = sanitize_patterns(metadata_config["data_files"])
             else:
                 data_files_to_dump = {}
+            # add the new split
             data_files_to_dump[split] = f"{data_dir}/{split}-*"
             metadata_config_to_dump = {
                 "data_files": [

--- a/src/datasets/data_files.py
+++ b/src/datasets/data_files.py
@@ -113,6 +113,14 @@ def sanitize_patterns(patterns: Union[Dict, List, str]) -> Dict[str, Union[List[
         return {SANITIZED_DEFAULT_SPLIT: [patterns]}
     elif isinstance(patterns, list):
         if any(isinstance(pattern, dict) for pattern in patterns):
+            for pattern in patterns:
+                if not isinstance(pattern, dict) or sorted(pattern) != ["pattern", "split"]:
+                    raise ValueError(
+                        f"Expected data_files in YAML to be a string or a list, but got {pattern}\nExamples:\n"
+                        "    data_files: data.csv\n    data_files: data/*.png\n"
+                        "    data_files:\n    - part0/*\n    - part1/*\n"
+                        "    data_files:\n    - split: train\n      pattern: train/*\n    - split: test\n      pattern: test/*"
+                    )
             splits = [pattern["split"] for pattern in patterns]
             if len(set(splits)) != len(splits):
                 raise ValueError(f"Some splits are duplicated in data_files: {splits}")

--- a/src/datasets/dataset_dict.py
+++ b/src/datasets/dataset_dict.py
@@ -5,6 +5,7 @@ import os
 import posixpath
 import re
 import warnings
+from fnmatch import fnmatch
 from io import BytesIO
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
@@ -17,6 +18,7 @@ from datasets.utils.metadata import DatasetMetadata, MetadataConfigs
 
 from . import config
 from .arrow_dataset import Dataset
+from .data_files import SPLIT_PATTERN_SHARDED, sanitize_patterns
 from .download import DownloadConfig
 from .features import Features
 from .features.features import FeatureType
@@ -30,7 +32,7 @@ from .utils import logging
 from .utils.doc_utils import is_documented_by
 from .utils.file_utils import cached_path
 from .utils.hub import hf_hub_url
-from .utils.py_utils import asdict
+from .utils.py_utils import asdict, string_to_dict
 from .utils.typing import PathLike
 
 
@@ -1580,7 +1582,7 @@ class DatasetDict(dict):
             if not re.match(_split_re, split):
                 raise ValueError(f"Split name should match '{_split_re}' but got '{split}'.")
 
-        data_dir = f"{config_name}/data" if config_name != "default" else "data"  # for backward compatibility
+        data_dir = config_name if config_name != "default" else "data"  # for backward compatibility
         for split in self.keys():
             logger.warning(f"Pushing split {split} to the Hub.")
             # The split=key needs to be removed before merging
@@ -1606,6 +1608,68 @@ class DatasetDict(dict):
         api = HfApi(endpoint=config.HF_ENDPOINT)
         repo_files = api.list_repo_files(repo_id, repo_type="dataset", revision=branch, token=token)
 
+        # get the info from the README to update them
+        if "README.md" in repo_files:
+            download_config = DownloadConfig()
+            download_config.download_desc = "Downloading metadata"
+            download_config.use_auth_token = token
+            dataset_readme_path = cached_path(
+                hf_hub_url(repo_id, "README.md"),
+                download_config=download_config,
+            )
+            dataset_metadata = DatasetMetadata.from_readme(Path(dataset_readme_path))
+            dataset_infos: DatasetInfosDict = DatasetInfosDict.from_metadata(dataset_metadata)
+            metadata_configs = MetadataConfigs.from_metadata(dataset_metadata)
+        # get the deprecated dataset_infos.json to update them
+        elif config.DATASETDICT_INFOS_FILENAME in repo_files:
+            dataset_metadata = DatasetMetadata()
+            metadata_configs = MetadataConfigs()
+            download_config = DownloadConfig()
+            download_config.download_desc = "Downloading metadata"
+            download_config.use_auth_token = token
+            dataset_infos_path = cached_path(
+                hf_hub_url(repo_id, config.DATASETDICT_INFOS_FILENAME),
+                download_config=download_config,
+            )
+            with open(dataset_infos_path, encoding="utf-8") as f:
+                dataset_infos: dict = json.load(f)
+                dataset_infos.get(config_name, None) if dataset_infos else None
+        else:
+            dataset_metadata = DatasetMetadata()
+            metadata_configs = MetadataConfigs()
+        # create the metadata configs if it was uploaded with push_to_hub before metadata configs existed
+        if not metadata_configs:
+            _matched_paths = [p for p in repo_files if fnmatch(p, SPLIT_PATTERN_SHARDED.replace("{split}", "*"))]
+            if len(_matched_paths) > 0:
+                # it was uploaded with push_to_hub before metadata configs existed
+                _resolved_splits = {
+                    string_to_dict(p.as_posix(), SPLIT_PATTERN_SHARDED)["split"] for p in _matched_paths
+                }
+                metadata_configs["default"] = {
+                    "data_files": [
+                        {"split": _resolved_split, "pattern": f"data/{_resolved_split}-*"}
+                        for _resolved_split in _resolved_splits
+                    ]
+                }
+        # update the metadata configs
+        if config_name in metadata_configs:
+            metadata_config = metadata_configs[config_name]
+            if "data_files" in metadata_config:
+                data_files_to_dump = sanitize_patterns(metadata_config["data_files"])
+            else:
+                data_files_to_dump = {}
+            data_files_to_dump[split] = f"{data_dir}/{split}-*"
+            metadata_config_to_dump = {
+                "data_files": [
+                    {
+                        "split": _split,
+                        "pattern": _pattern[0] if isinstance(_pattern, list) and len(_pattern) == 1 else _pattern,
+                    }
+                    for _split, _pattern in data_files_to_dump.items()
+                ]
+            }
+        else:
+            metadata_config_to_dump = {"data_files": [{"split": split, "pattern": f"{data_dir}/{split}-*"}]}
         # push to the deprecated dataset_infos.json
         if config.DATASETDICT_INFOS_FILENAME in repo_files:
             download_config = DownloadConfig()
@@ -1629,24 +1693,13 @@ class DatasetDict(dict):
                 revision=branch,
             )
         # push to README
+        DatasetInfosDict({config_name: info_to_dump}).to_metadata(dataset_metadata)
+        MetadataConfigs({config_name: metadata_config_to_dump}).to_metadata(dataset_metadata)
         if "README.md" in repo_files:
-            download_config = DownloadConfig()
-            download_config.download_desc = "Downloading metadata"
-            download_config.use_auth_token = token
-            dataset_readme_path = cached_path(
-                hf_hub_url(repo_id, "README.md"),
-                download_config=download_config,
-            )
-            dataset_metadata = DatasetMetadata.from_readme(Path(dataset_readme_path))
             with open(dataset_readme_path, encoding="utf-8") as readme_file:
                 readme_content = readme_file.read()
         else:
-            dataset_metadata = DatasetMetadata()
             readme_content = f'# Dataset Card for "{repo_id.split("/")[-1]}"\n\n[More Information needed](https://github.com/huggingface/datasets/blob/main/CONTRIBUTING.md#how-to-contribute-to-the-dataset-cards)'
-        DatasetInfosDict({config_name: info_to_dump}).to_metadata(dataset_metadata)
-        MetadataConfigs({config_name: {"data_dir": config_name if config_name != "default" else "./"}}).to_metadata(
-            dataset_metadata
-        )
         HfApi(endpoint=config.HF_ENDPOINT).upload_file(
             path_or_fileobj=dataset_metadata._to_readme(readme_content).encode(),
             path_in_repo="README.md",

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -153,7 +153,10 @@ class _InitializeConfiguredDatasetBuilder:
 
 
 def configure_builder_class(
-    builder_cls: Type[DatasetBuilder], builder_configs: List["BulderConfig"], dataset_name: str
+    builder_cls: Type[DatasetBuilder],
+    builder_configs: List["BulderConfig"],
+    default_config_name: Optional[str],
+    dataset_name: str,
 ) -> Type[DatasetBuilder]:
     """
     Dynamically create a builder class with custom builder configs parsed from README.md file,
@@ -162,6 +165,7 @@ def configure_builder_class(
 
     class ConfiguredDatasetBuilder(builder_cls):
         BUILDER_CONFIGS = builder_configs
+        DEFAULT_CONFIG_NAME = default_config_name
 
         __module__ = builder_cls.__module__  # so that the actual packaged builder can be imported
 
@@ -187,14 +191,18 @@ def configure_builder_class(
     return ConfiguredDatasetBuilder
 
 
-def get_dataset_builder_class(dataset_module, dataset_name: Optional[str] = None) -> Type[DatasetBuilder]:
+def get_dataset_builder_class(
+    dataset_module: "DatasetModule", dataset_name: Optional[str] = None
+) -> Type[DatasetBuilder]:
     builder_cls = import_main_class(dataset_module.module_path)
     if dataset_module.metadata_configs:
         config_cls = builder_cls.BUILDER_CONFIG_CLASS
         builder_configs_list = dataset_module.metadata_configs.to_builder_configs_list(builder_config_cls=config_cls)
+        default_config_name = dataset_module.metadata_configs.get_default_config_name()
         builder_cls = configure_builder_class(
             builder_cls,
             builder_configs=builder_configs_list,
+            default_config_name=default_config_name,
             dataset_name=dataset_name,
         )
     return builder_cls

--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -198,7 +198,7 @@ class MetadataConfigs(Dict[str, Dict[str, Any]]):
             param
             for meta_config in metadata_configs.values()
             for param in meta_config
-            if hasattr(builder_config_cls, param) and param != "default"
+            if not hasattr(builder_config_cls, param) and param != "default"
         ]
         if ignored_params:
             logger.warning(

--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -218,6 +218,18 @@ class MetadataConfigs(Dict[str, Dict[str, Any]]):
             for name, meta_config in metadata_configs.items()
         ]
 
+    def get_default_config_name(self) -> Optional[str]:
+        default_config_name = None
+        for config_name, metadata_config in self.items():
+            if config_name == "default" or metadata_config.get("default"):
+                if default_config_name is None:
+                    default_config_name = config_name
+                else:
+                    raise ValueError(
+                        f"Dataset has several default configs: '{default_config_name}' and '{config_name}'."
+                    )
+        return default_config_name
+
     def resolve_data_files_locally(
         self,
         base_path: str,

--- a/tests/test_upstream_hub.py
+++ b/tests/test_upstream_hub.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import time
 import unittest
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,7 +11,17 @@ import numpy as np
 import pytest
 from huggingface_hub import HfApi
 
-from datasets import Audio, ClassLabel, Dataset, DatasetDict, Features, Image, Value, load_dataset
+from datasets import (
+    Audio,
+    ClassLabel,
+    Dataset,
+    DatasetDict,
+    Features,
+    Image,
+    Value,
+    load_dataset,
+    load_dataset_builder,
+)
 from datasets.config import METADATA_CONFIGS_FIELD
 from datasets.utils.file_utils import cached_path
 from datasets.utils.hub import hf_hub_url
@@ -608,3 +619,67 @@ class TestPushToHub:
                 assert local_ds.column_names == hub_ds.column_names
                 assert list(local_ds["train"].features.keys()) == list(hub_ds["train"].features.keys())
                 assert local_ds["train"].features == hub_ds["train"].features
+
+    def test_push_dataset_to_hub_with_config_no_metadata_configs(self, temporary_repo):
+        ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
+        ds_another_config = Dataset.from_dict({"foo": [1, 2], "bar": [4, 5]})
+        parquet_buf = BytesIO()
+        ds.to_parquet(parquet_buf)
+        parquet_content = parquet_buf.getvalue()
+
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+            self._api.create_repo(ds_name, token=self._token, repo_type="dataset")
+            # old push_to_hub was uploading the pqrauet fiels only - without metadata configs
+            self._api.upload_file(
+                path_or_fileobj=parquet_content,
+                path_in_repo="data/train-00000-of-00001.parquet",
+                repo_id=ds_name,
+                repo_type="dataset",
+            )
+            ds_another_config.push_to_hub(ds_name, "another_config", token=self._token)
+            ds_builder = load_dataset_builder(ds_name, download_mode="force_redownload")
+            assert len(ds_builder.config.data_files["train"]) == 1
+            assert len(ds_builder.config.data_files) == 1
+            assert fnmatch.fnmatch(ds_builder.config.data_files["train"][0], "*/data/train-00000-of-00001.parquet")
+            ds_another_config_builder = load_dataset_builder(
+                ds_name, "another_config", download_mode="force_redownload"
+            )
+            assert len(ds_another_config_builder.config.data_files) == 1
+            assert len(ds_another_config_builder.config.data_files["train"]) == 1
+            assert fnmatch.fnmatch(
+                ds_another_config_builder.config.data_files["train"][0],
+                "*/another_config/train-00000-of-00001-*.parquet",
+            )
+
+    def test_push_dataset_dict_to_hub_with_config_no_metadata_configs(self, temporary_repo):
+        ds = Dataset.from_dict({"x": [1, 2, 3], "y": [4, 5, 6]})
+        ds_another_config = Dataset.from_dict({"foo": [1, 2], "bar": [4, 5]})
+        parquet_buf = BytesIO()
+        ds.to_parquet(parquet_buf)
+        parquet_content = parquet_buf.getvalue()
+
+        local_ds_another_config = DatasetDict({"random": ds_another_config})
+
+        with temporary_repo(f"{CI_HUB_USER}/test-{int(time.time() * 10e3)}") as ds_name:
+            self._api.create_repo(ds_name, token=self._token, repo_type="dataset")
+            # old push_to_hub was uploading the pqrauet fiels only - without metadata configs
+            self._api.upload_file(
+                path_or_fileobj=parquet_content,
+                path_in_repo="data/random-00000-of-00001.parquet",
+                repo_id=ds_name,
+                repo_type="dataset",
+            )
+            local_ds_another_config.push_to_hub(ds_name, "another_config", token=self._token)
+            ds_builder = load_dataset_builder(ds_name, download_mode="force_redownload")
+            assert len(ds_builder.config.data_files) == 1
+            assert len(ds_builder.config.data_files["random"]) == 1
+            assert fnmatch.fnmatch(ds_builder.config.data_files["random"][0], "*/data/random-00000-of-00001.parquet")
+            ds_another_config_builder = load_dataset_builder(
+                ds_name, "another_config", download_mode="force_redownload"
+            )
+            assert len(ds_another_config_builder.config.data_files) == 1
+            assert len(ds_another_config_builder.config.data_files["random"]) == 1
+            assert fnmatch.fnmatch(
+                ds_another_config_builder.config.data_files["random"][0],
+                "*/another_config/random-00000-of-00001-*.parquet",
+            )


### PR DESCRIPTION
Introducing

```yaml
builder_config:
  data_files:
  - split: train
    pattern: data/train-*
```

when pushing a dataset in the README.md.

I also updated `sanitize_patterns` to support this structure as input before passing it to `DataFilesDict.from_*`

When pushing a new config to a dataset that was pushed using an old `push_to_hub`, the YAML is also created automatically for the old config.

Regarding default configs: a config is the default one if it's called "default" or if it has a "default: true" in YAML

If it looks good for you I can add some tests