### PR TITLE
Separate DataFilesDict and MetadataConfigs

### DIFF
--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -786,6 +786,8 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
                 legacy_dataset_infos: DatasetInfosDict = json.load(f)
             legacy_dataset_infos.update(dataset_infos)
             dataset_infos = legacy_dataset_infos
+        if default_config_name is None and len(dataset_infos) == 1:
+            default_config_name = next(iter(dataset_infos))
 
         return DatasetModule(
             module_path,
@@ -962,6 +964,8 @@ class HubDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
             dataset_infos = legacy_dataset_infos
         except FileNotFoundError:
             pass
+        if default_config_name is None and len(dataset_infos) == 1:
+            default_config_name = next(iter(dataset_infos))
 
         return DatasetModule(
             module_path,

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1652,7 +1652,7 @@ def load_dataset_builder(
     builder_kwargs = dataset_module.builder_kwargs
     data_dir = builder_kwargs.pop("data_dir", data_dir)
     data_files = builder_kwargs.pop("data_files", data_files)
-    config_name = builder_kwargs.pop("config_name", name or dataset_module.default_config_name or "default")
+    config_name = builder_kwargs.pop("config_name", name or dataset_module.default_config_name or None)
     hash = builder_kwargs.pop("hash")
     if dataset_module.dataset_infos and config_name in dataset_module.dataset_infos:
         info = dataset_module.dataset_infos[config_name]

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -758,6 +758,7 @@ class LocalDatasetModuleFactoryWithoutScript(_DatasetModuleFactory):
             builder_configs = []
             for config_name in metadata_configs:
                 config_data_files = metadata_configs.resolve_data_files_locally(
+                    config_name=config_name,
                     base_path=self.path,
                     with_metadata_files=supports_metadata,
                     allowed_extensions=ALL_ALLOWED_EXTENSIONS,

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -1647,9 +1647,12 @@ def load_dataset_builder(
     builder_kwargs = dataset_module.builder_kwargs
     data_dir = builder_kwargs.pop("data_dir", data_dir)
     data_files = builder_kwargs.pop("data_files", data_files)
-    config_name = builder_kwargs.pop("config_name", name or dataset_module.default_config_name)
+    config_name = builder_kwargs.pop("config_name", name or dataset_module.default_config_name or "default")
     hash = builder_kwargs.pop("hash")
-
+    if dataset_module.dataset_infos and config_name in dataset_module.dataset_infos:
+        info = dataset_module.dataset_infos[config_name]
+    else:
+        info = None
     if dataset_module.metadata_configs and config_name in dataset_module.metadata_configs:
         hash = update_hash_with_config_parameters(hash, dataset_module.metadata_configs[config_name])
 
@@ -1670,6 +1673,7 @@ def load_dataset_builder(
         data_dir=data_dir,
         data_files=data_files,
         hash=hash,
+        info=info,
         features=features,
         use_auth_token=use_auth_token,
         storage_options=storage_options,

--- a/src/datasets/load.py
+++ b/src/datasets/load.py
@@ -26,7 +26,7 @@ import warnings
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Type, Union
 
 import fsspec
 import requests
@@ -419,7 +419,7 @@ def _create_importable_file(
 
 def infer_module_for_data_files(
     data_files_list: DataFilesList, use_auth_token: Optional[Union[bool, str]] = None
-) -> Optional[Tuple[str, str]]:
+) -> Tuple[Optional[str], Dict[str, Any]]:
     """Infer module (and builder kwargs) from list of data files.
 
     Args:
@@ -448,7 +448,7 @@ def infer_module_for_data_files(
 
 def infer_module_for_data_files_in_archives(
     data_files_list: DataFilesList, use_auth_token: Optional[Union[bool, str]]
-) -> Optional[Tuple[str, str]]:
+) -> Tuple[Optional[str], Dict[str, Any]]:
     """Infer module (and builder kwargs) from list of archive data files.
 
     Args:

--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -1,8 +1,7 @@
-import copy
 import os
 from collections import Counter
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, Type, Union
 
 import huggingface_hub
 import yaml
@@ -18,6 +17,10 @@ from ..data_files import (
     sanitize_patterns,
 )
 from ..utils.logging import get_logger
+
+
+if TYPE_CHECKING:
+    from ..builder import BuilderConfig
 
 
 logger = get_logger(__name__)
@@ -183,22 +186,18 @@ class MetadataConfigs(Dict[str, Dict[str, Any]]):
                 )
                 dataset_metadata[self.__configs_field_name] = metadata_config
 
-    def to_builder_configs(self, builder_config_cls):
+    def get_builder_config(
+        self,
+        config_name: str,
+        builder_config_cls: Type["BuilderConfig"],
+        data_files: Optional[DataFilesDict],
+        data_dir: Optional[str],
+        default_builder_kwargs: Optional[Dict[str, Any]],
+    ) -> "BuilderConfig":
         """Convert configurations parsed from metadata file to list of BuilderConfig objects."""
-        metadata_configs = copy.deepcopy(self)
-        for config_name, metadata_config in metadata_configs.items():
-            if "data_files" in metadata_config and not isinstance(metadata_config["data_files"], DataFilesDict):
-                raise ValueError(
-                    f"""`data_files` parameter of config {config_name} should be an instance of DataFilesDict
-                    but it's {type(metadata_config["data_files"])}.
-                    You can resolve data files with either .resolve_data_files_locally() or
-                    .resolve_data_files_in_dataset_repository() method."""
-                )
+        meta_config = self[config_name]
         ignored_params = [
-            param
-            for meta_config in metadata_configs.values()
-            for param in meta_config
-            if not hasattr(builder_config_cls, param) and param != "default"
+            param for param in meta_config if not hasattr(builder_config_cls, param) and param != "default"
         ]
         if ignored_params:
             logger.warning(
@@ -206,17 +205,16 @@ class MetadataConfigs(Dict[str, Dict[str, Any]]):
                 "Make sure to use only valid params for the dataset builder and to have "
                 "a up-to-date version of the `datasets` library."
             )
-        return [
-            builder_config_cls(
-                name=name,
-                **{
-                    param: value
-                    for param, value in meta_config.items()
-                    if hasattr(builder_config_cls, param) and param != "default"
-                },
-            )
-            for name, meta_config in metadata_configs.items()
-        ]
+        return builder_config_cls(
+            name=config_name,
+            data_files=data_files,
+            data_dir=data_dir,
+            **{
+                param: value
+                for param, value in {**default_builder_kwargs, **meta_config}.items()
+                if hasattr(builder_config_cls, param) and param not in ("default", "data_files", "data_dir")
+            },
+        )
 
     def get_default_config_name(self) -> Optional[str]:
         default_config_name = None
@@ -232,67 +230,65 @@ class MetadataConfigs(Dict[str, Dict[str, Any]]):
 
     def resolve_data_files_locally(
         self,
+        config_name: str,
         base_path: str,
         with_metadata_files: bool,
         allowed_extensions: List[str],
-    ) -> None:
+    ) -> DataFilesDict:
         """
         Find patterns and resolve data files for local datasets for each config in-place (i.e. modifying `self`).
         Drop initial `data_dir` and `data_files` values and set `data_files` to DataFilesDict object with resolved data files.
         """
-        for metadata_config in self.values():
-            config_data_files = metadata_config.pop("data_files", None)
-            config_data_dir = metadata_config.pop("data_dir", None)
-            config_base_path = os.path.join(base_path, config_data_dir) if config_data_dir else base_path
-            config_patterns = (
-                sanitize_patterns(config_data_files)
-                if config_data_files is not None
-                else get_data_patterns_locally(config_base_path)
-            )
-            config_data_files_dict = DataFilesDict.from_local_or_remote(
-                config_patterns,
-                base_path=config_base_path,
-                allowed_extensions=allowed_extensions,
-            )
-            metadata_config["data_files"] = config_data_files_dict
-
-            if config_data_files is None and with_metadata_files and config_patterns != DEFAULT_PATTERNS_ALL:
-                extend_data_files_with_metadata_files_locally(
-                    metadata_config["data_files"], base_path=config_base_path
-                )
+        metadata_config = self[config_name]
+        config_data_files = metadata_config.get("data_files")
+        config_data_dir = metadata_config.get("data_dir")
+        config_base_path = os.path.join(base_path, config_data_dir) if config_data_dir else base_path
+        config_patterns = (
+            sanitize_patterns(config_data_files)
+            if config_data_files is not None
+            else get_data_patterns_locally(config_base_path)
+        )
+        config_data_files_dict = DataFilesDict.from_local_or_remote(
+            config_patterns,
+            base_path=config_base_path,
+            allowed_extensions=allowed_extensions,
+        )
+        if config_data_files is None and with_metadata_files and config_patterns != DEFAULT_PATTERNS_ALL:
+            extend_data_files_with_metadata_files_locally(config_data_files_dict, base_path=config_base_path)
+        return config_data_files_dict
 
     def resolve_data_files_in_dataset_repository(
         self,
+        config_name: str,
         hfh_dataset_info: huggingface_hub.hf_api.DatasetInfo,
         base_path: str,
         with_metadata_files: bool,
         allowed_extensions: List[str],
-    ) -> None:
+    ) -> DataFilesDict:
         """
         Find patterns and resolve data files for Hub datasets for each config in-place (i.e. modifying `self`).
         Drop initial `data_dir` and `data_files` values and set `data_files` to DataFilesDict object with resolved data files.
         """
-        for metadata_config in self.values():
-            config_data_files = metadata_config.pop("data_files", None)
-            config_data_dir = metadata_config.pop("data_dir", None)
-            config_base_path = os.path.join(base_path, config_data_dir) if config_data_dir else base_path
-            config_patterns = (
-                sanitize_patterns(config_data_files)
-                if config_data_files is not None
-                else get_data_patterns_in_dataset_repository(hfh_dataset_info, config_base_path)
+        metadata_config = self[config_name]
+        config_data_files = metadata_config.get("data_files")
+        config_data_dir = metadata_config.get("data_dir")
+        config_base_path = os.path.join(base_path, config_data_dir) if config_data_dir else base_path
+        config_patterns = (
+            sanitize_patterns(config_data_files)
+            if config_data_files is not None
+            else get_data_patterns_in_dataset_repository(hfh_dataset_info, config_base_path)
+        )
+        config_data_files_dict = DataFilesDict.from_hf_repo(
+            config_patterns,
+            dataset_info=hfh_dataset_info,
+            base_path=config_base_path,
+            allowed_extensions=allowed_extensions,
+        )
+        if config_data_files is None and with_metadata_files and config_patterns != DEFAULT_PATTERNS_ALL:
+            extend_data_files_with_metadata_files_in_dataset_repository(
+                hfh_dataset_info, data_files=config_data_files_dict, base_path=config_base_path
             )
-            config_data_files_dict = DataFilesDict.from_hf_repo(
-                config_patterns,
-                dataset_info=hfh_dataset_info,
-                base_path=config_base_path,
-                allowed_extensions=allowed_extensions,
-            )
-            metadata_config["data_files"] = config_data_files_dict
-
-            if config_data_files is None and with_metadata_files and config_patterns != DEFAULT_PATTERNS_ALL:
-                extend_data_files_with_metadata_files_in_dataset_repository(
-                    hfh_dataset_info, data_files=metadata_config["data_files"], base_path=config_base_path
-                )
+        return config_data_files_dict
 
 
 # DEPRECATED - just here to support old versions of evaluate like 0.2.2

--- a/src/datasets/utils/metadata.py
+++ b/src/datasets/utils/metadata.py
@@ -192,7 +192,7 @@ class MetadataConfigs(Dict[str, Dict[str, Any]]):
         builder_config_cls: Type["BuilderConfig"],
         data_files: Optional[DataFilesDict],
         data_dir: Optional[str],
-        default_builder_kwargs: Optional[Dict[str, Any]],
+        default_builder_kwargs: Dict[str, Any],
     ) -> "BuilderConfig":
         """Convert configurations parsed from metadata file to list of BuilderConfig objects."""
         meta_config = self[config_name]

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -35,8 +35,8 @@ from datasets.load import (
     infer_module_for_data_files,
     infer_module_for_data_files_in_archives,
 )
-from datasets.packaged_modules.audiofolder.audiofolder import AudioFolderConfig
-from datasets.packaged_modules.imagefolder.imagefolder import ImageFolderConfig
+from datasets.packaged_modules.audiofolder.audiofolder import AudioFolder, AudioFolderConfig
+from datasets.packaged_modules.imagefolder.imagefolder import ImageFolder, ImageFolderConfig
 
 from .utils import (
     OfflineSimulationMode,
@@ -939,6 +939,39 @@ class LoadTest(TestCase):
                 with self.assertRaises(ConnectionError) as context:
                     datasets.load_dataset("lhoestq/_dummy")
                 self.assertIn("lhoestq/_dummy", str(context.exception))
+
+
+@pytest.mark.integration
+def test_load_dataset_builder_with_metadata():
+    builder = datasets.load_dataset_builder(SAMPLE_DATASET_IDENTIFIER4)
+    assert isinstance(builder, ImageFolder)
+    assert builder.config.name == "default"
+    assert builder.config.data_files is not None
+    builder = datasets.load_dataset_builder(SAMPLE_DATASET_IDENTIFIER4, "non-existing-config")
+    assert isinstance(builder, ImageFolder)
+    assert builder.config.name == "non-existing-config"
+
+
+@pytest.mark.integration
+def test_load_dataset_builder_with_one_nondefault_config_in_metadata():
+    builder = datasets.load_dataset_builder(SAMPLE_DATASET_ONE_NONDEFAULT_CONFIG_IN_METADATA)
+    assert isinstance(builder, AudioFolder)
+    assert builder.config.name == "custom"
+    assert builder.config.data_files is not None
+    with pytest.raises(ValueError):
+        datasets.load_dataset_builder(SAMPLE_DATASET_ONE_NONDEFAULT_CONFIG_IN_METADATA, "non-existing-config")
+
+
+@pytest.mark.integration
+def test_load_dataset_builder_with_two_configs_in_metadata():
+    builder = datasets.load_dataset_builder(SAMPLE_DATASET_TWO_CONFIG_IN_METADATA, "v1")
+    assert isinstance(builder, AudioFolder)
+    assert builder.config.name == "v1"
+    assert builder.config.data_files is not None
+    with pytest.raises(ValueError):
+        datasets.load_dataset_builder(SAMPLE_DATASET_TWO_CONFIG_IN_METADATA)
+    with pytest.raises(ValueError):
+        datasets.load_dataset_builder(SAMPLE_DATASET_TWO_CONFIG_IN_METADATA, "non-existing-config")
 
 
 def test_load_dataset_builder_for_absolute_script_dir(dataset_loading_script_dir, data_dir):

--- a/tests/test_metadata_util.py
+++ b/tests/test_metadata_util.py
@@ -281,12 +281,10 @@ def test_metadata_configs_resolve_data_files_locally(data_dir_with_two_subdirs):
             "dogs": {"data_dir": "dogs"},
         }
     )
-    metadata_configs_dict.resolve_data_files_locally(
-        base_path=data_dir_with_two_subdirs, with_metadata_files=False, allowed_extensions=["jpg"]
-    )
-    for config_name, config in metadata_configs_dict.items():
-        assert "data_files" in config
-        config_data_files = config["data_files"]
+    for config_name in metadata_configs_dict:
+        config_data_files = metadata_configs_dict.resolve_data_files_locally(
+            config_name, base_path=data_dir_with_two_subdirs, with_metadata_files=False, allowed_extensions=["jpg"]
+        )
         assert isinstance(config_data_files, DataFilesDict)
         assert len(config_data_files) == 1  # there is a single split
         assert len(config_data_files["train"]) == 1
@@ -310,12 +308,9 @@ def test_metadata_configs_resolve_data_files_in_dataset_repository(
         SAMPLE_DATASET_TWO_CONFIG_IN_METADATA,
         timeout=100.0,
     )
-    metadata_configs_dict.resolve_data_files_in_dataset_repository(
-        hfh_dataset_info, base_path="", with_metadata_files=False, allowed_extensions=["flac"]
+    config_data_files = metadata_configs_dict.resolve_data_files_in_dataset_repository(
+        config_name, hfh_dataset_info, base_path="", with_metadata_files=False, allowed_extensions=["flac"]
     )
-    config = metadata_configs_dict[config_name]
-    assert "data_files" in config
-    config_data_files = config["data_files"]
     assert isinstance(config_data_files, DataFilesDict)
     assert len(config_data_files["train"]) == expected_train_samples
     assert len(config_data_files["test"]) == expected_test_samples


### PR DESCRIPTION
I did a few changes:
- `MetadataConfigs.resolve_data_files_locally` returns a `DataFilesDict` given a config name
- `MetadataConfigs.get_builder_config` returns a `BuilderConfig` given a config name
- `DatasetModule` has optional attributes:
  - dataset_infos: to pass`info=` to `builder_cls()` if the requested config has a dataset_info
  - metadata_configs: to update the builder's hash if the requested config has a metadata_config
  - builder_configs: to configure the builder class
  - default_config_name: to configure the builder class
```python

@dataclass
class DatasetModule:
    module_path: str
    hash: str
    builder_kwargs: dict
    dataset_infos: Optional[DatasetInfosDict] = None
    metadata_configs: Optional[MetadataConfigs] = None
    builder_configs: Optional[List[BuilderConfig]] = None
    default_config_name: Optional[str] = None

```
- other minor improvements
  - removed `get_dataset_info_from_dataset_metadata` since we can just use `DatasetInfosDict.from_metadata`
  - removed `get_dataset_info_from_dataset_infos_json` since we need the full dataset_infos now - I reused the old code

Therefore MetadataConfigs is not modified in place anymore, which makes the logic easier to manipulate IMO